### PR TITLE
Fix Capybara-Webkit deprecation warning

### DIFF
--- a/lib/pretender/rails/server.rb
+++ b/lib/pretender/rails/server.rb
@@ -18,10 +18,8 @@ module Pretender
 
       def shutdown(page)
         stubs.clear
-        if page.driver.browser.respond_to? :execute_script
-          page.execute_script('typeof(server) !== "undefined" && server.shutdown();')
-        end
-      rescue Capybara::NotSupportedByDriver => e
+        page.driver.execute_script('typeof(server) !== "undefined" && server.shutdown();')
+      rescue Capybara::NotSupportedByDriverError => e
       end
 
       def stub(method, route, response)


### PR DESCRIPTION
Hey Chase:

Pretender-Rails was throwing a deprecation error when using it with Cucumber and Capybara-Webkit.

`[DEPRECATION] Capybara::Webkit::Driver#browser is deprecated`

I tracked it down to `page.driver.browser.respond_to?(:execute_script)` in pretender-rails.

The good news is that the APIs for the `Driver` class in rack-test, poltergeist, and capybara-webkit all respond to `#execute_script`. [Rack-test will throw](https://github.com/jnicklas/capybara/blob/master/lib/capybara/driver/base.rb#L34) a `Capybara::NotSupportedByDriverError`

This PR will call `#execute_script` directly on the driver, and it will get rescued if the driver doesn't implement that method. 

References:

[Capybara-Webkit Browser class](https://github.com/thoughtbot/capybara-webkit/blob/master/lib/capybara/webkit/driver.rb#L77)
[Poltergeist Browser class](https://github.com/teampoltergeist/poltergeist/blob/master/lib/capybara/poltergeist/driver.rb#L139)
